### PR TITLE
Fix code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/quartz/components/scripts/explorer-burger.inline.ts
+++ b/quartz/components/scripts/explorer-burger.inline.ts
@@ -5,7 +5,7 @@ type MaybeHTMLElement = HTMLElement | undefined
 let currentExplorerState: FolderState[]
 
 function escapeCharacters(str: string) {
-  return str.replace(/'/g, "\\'").replace(/"/g, '\\"')
+  return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"')
 }
 
 const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
Fixes [https://github.com/saberzero1/quartz/security/code-scanning/7](https://github.com/saberzero1/quartz/security/code-scanning/7)

To fix the problem, we need to ensure that all special characters, including backslashes, are properly escaped. The best way to achieve this is by using a well-tested sanitization library. However, if we must implement a custom solution, we should use a regular expression to escape backslashes first and then escape other special characters.

1. Modify the `escapeCharacters` function to escape backslashes before escaping single and double quotes.
2. Ensure that the regular expression used for escaping backslashes has the global flag to replace all occurrences.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
