### PR TITLE
Fix code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/quartz/components/ExplorerNode.tsx
+++ b/quartz/components/ExplorerNode.tsx
@@ -135,7 +135,7 @@ export class FileNode {
       if (!node.file) {
         const folderPath = joinSegments(currentPath, node.name)
         const collapseState = !currentFile.includes(
-          folderPath.replace("'", "-").replaceAll("../", ""),
+          folderPath.replace(/'/g, "-").replaceAll("../", ""),
         )
         //console.log(currentFile, folderPath, collapseState)
         if (folderPath !== "") {


### PR DESCRIPTION
Fixes [https://github.com/saberzero1/quartz/security/code-scanning/5](https://github.com/saberzero1/quartz/security/code-scanning/5)

To fix the problem, we should ensure that all occurrences of the single quote character in the `folderPath` string are replaced. This can be achieved by using a regular expression with the global flag (`g`). This approach ensures that every instance of the single quote character is replaced, not just the first one.

- Modify the `replace` method call on line 138 to use a regular expression with the global flag.
- No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
