### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -375,7 +375,13 @@ export async function handleBuild(argv) {
         // /trailing/
         // does /trailing/index.html exist? if so, serve it
         const indexFp = path.posix.join(fp, "index.html")
-        if (fs.existsSync(path.posix.join(argv.output, indexFp))) {
+        const fullIndexFp = path.resolve(argv.output, indexFp)
+        if (!fullIndexFp.startsWith(path.resolve(argv.output))) {
+          res.statusCode = 403
+          res.end()
+          return
+        }
+        if (fs.existsSync(fullIndexFp)) {
           req.url = fp
           return serve()
         }
@@ -385,7 +391,13 @@ export async function handleBuild(argv) {
         if (path.extname(base) === "") {
           base += ".html"
         }
-        if (fs.existsSync(path.posix.join(argv.output, base))) {
+        const fullBaseFp = path.resolve(argv.output, base)
+        if (!fullBaseFp.startsWith(path.resolve(argv.output))) {
+          res.statusCode = 403
+          res.end()
+          return
+        }
+        if (fs.existsSync(fullBaseFp)) {
           return redirect(fp.slice(0, -1))
         }
       } else {
@@ -395,14 +407,26 @@ export async function handleBuild(argv) {
         if (path.extname(base) === "") {
           base += ".html"
         }
-        if (fs.existsSync(path.posix.join(argv.output, base))) {
+        const fullBaseFp = path.resolve(argv.output, base)
+        if (!fullBaseFp.startsWith(path.resolve(argv.output))) {
+          res.statusCode = 403
+          res.end()
+          return
+        }
+        if (fs.existsSync(fullBaseFp)) {
           req.url = fp
           return serve()
         }
 
         // does /regular/index.html exist? if so, redirect to /regular/
         let indexFp = path.posix.join(fp, "index.html")
-        if (fs.existsSync(path.posix.join(argv.output, indexFp))) {
+        const fullIndexFp = path.resolve(argv.output, indexFp)
+        if (!fullIndexFp.startsWith(path.resolve(argv.output))) {
+          res.statusCode = 403
+          res.end()
+          return
+        }
+        if (fs.existsSync(fullIndexFp)) {
           return redirect(fp + "/")
         }
       }


### PR DESCRIPTION
Fixes [https://github.com/saberzero1/quartz/security/code-scanning/1](https://github.com/saberzero1/quartz/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file paths are validated and sanitized before being used. We can achieve this by normalizing the paths and ensuring they are contained within a safe root directory. This involves:
1. Normalizing the path using `path.resolve` to remove any ".." segments.
2. Checking that the normalized path starts with the root directory.

We will apply these changes to the relevant parts of the code where file paths are constructed and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
